### PR TITLE
fix dark mode on Pop!_OS & hide "Open in iTunes" button

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,9 @@ function createWindow() {
   win.setMenuBarVisibility(false);
   // loads apple music webplayer
   win.loadURL('http://music.apple.com');
+  // fix for dark mode on popos (and possibly other distros)
+  // overrides and supersedes the value that Chromium has chosen to use internally
+   if(nativeTheme.shouldUseDarkColors) nativeTheme.themeSource = 'dark';
   // injects css from styles.css
   win.webContents.on('did-finish-load', function() {
       fs.readFile(__dirname + '/styles.css', "utf-8", function(error, data) {

--- a/styles.css
+++ b/styles.css
@@ -23,3 +23,8 @@ Not supports in Firefox and IE */
 ::-webkit-scrollbar-button {
   display:none;
 }
+
+/* hide "Open in iTunes" button */
+.web-navigation__native-upsell {
+  display: none;
+}


### PR DESCRIPTION
Fixes dark mode based on OS setting on Pop!_OS and hides the unnecessary open in iTunes button