### PR TITLE
Added custom settings for Beta & Dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "electron-window-state": "5.0.3",
     "electron-updater": "4.3.5",
-    "electron-log": "^1.3.0"
+    "electron-log": "^1.3.0",
+    "electron-store": "^6.0.1"
   },
   "devDependencies": {
     "electron": "https://github.com/castlabs/electron-releases#v8.5.3-wvvmp",


### PR DESCRIPTION
Custom Electron menu, saves settings using electron-store.
If dark mode switch wasn't used yet, it will use the system preference