### PR TITLE
Bump electron-builder from 22.7.0 to 22.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
   },
   "dependencies": {
     "electron-log": "^1.3.0",
+    "electron-prompt": "1.6.0",
     "electron-store": "^6.0.1",
     "electron-updater": "4.3.5",
     "electron-window-state": "5.0.3",
-    "electron-prompt": "1.6.0",
     "express": "^4.17.1",
     "express-asset-file-cache-middleware": "^1.3.0",
     "v8-compile-cache": "^2.2.0"
   },
   "devDependencies": {
     "electron": "https://github.com/castlabs/electron-releases#v8.5.3-wvvmp",
-    "electron-builder": "^22.7.0",
+    "electron-builder": "22.11.4",
     "electron-webpack": "^2.8.2",
     "webpack": "~4.42.1"
   },


### PR DESCRIPTION
Electron builder fails to build app on node 16, which means that package managers on platforms with Node 16 will fail to install the app with a cryptic error. Bump electron-builder version to fix this. 

This version is a pre-release from a few hours ago, so it might be better to wait a few days until it is properly released.